### PR TITLE
Update edit coupon handling

### DIFF
--- a/src/FrontPgCupons/cuponsPage.jsx
+++ b/src/FrontPgCupons/cuponsPage.jsx
@@ -104,7 +104,16 @@ const CuponsPage = () => {
   }, []);
 
   const handleEditCoupon = (coupon) => {
-    setEditingCoupon(coupon);
+    // Quando seleciona um cupom para edição, normaliza os dados para o formulário
+    setEditingCoupon({
+      id: coupon.id,
+      nome: coupon.nome,
+      descricao: coupon.descricao,
+      expiration: coupon.expiration,
+      // a API retorna "estabelecimento_id", mas o formulário espera
+      // o campo "estabelecimento"
+      estabelecimento: coupon.estabelecimento_id,
+    });
   };
 
   const handleDeleteCoupon = async (id) => {


### PR DESCRIPTION
## Summary
- map coupon fields when setting edit state so the form shows existing data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f50b9dd4c8330b46c71738ddffa2e